### PR TITLE
Fix typo in AdminAsignar method name

### DIFF
--- a/ApiMETA/Controllers/RoleUsersControllers.cs
+++ b/ApiMETA/Controllers/RoleUsersControllers.cs
@@ -13,7 +13,7 @@ namespace ApiMETA.Controllers
         [Authorize]
         [Route("AsignRole")]
         [HttpPost]
-        public int AdminAsignarl(AdminUserRol adminUserRol)
+        public int AdminAsignar(AdminUserRol adminUserRol)
         {
             int respuesta = 0;
             Globals.Log(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + " INFO " + System.Reflection.MethodBase.GetCurrentMethod().Name + ": Start: " + adminUserRol + "  \n");


### PR DESCRIPTION
## Summary
- Rename `AdminAsignarl` to `AdminAsignar` in `RoleUsersControllers`

## Testing
- `dotnet build ApiMETA.sln` *(fails: Microsoft.WebApplication.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1935004808325b55b1dc1dcd5ecc2